### PR TITLE
Remove loop parameter from open_connection()

### DIFF
--- a/scanner/modules/core_scanner.py
+++ b/scanner/modules/core_scanner.py
@@ -80,7 +80,7 @@ class AsyncTCPScanner:
 
         try:
             await asyncio.wait_for(
-                asyncio.open_connection(address, port, loop=self._loop),
+                asyncio.open_connection(address, port),
                 timeout=self.timeout
             )
             port_state, reason = 'open', 'SYN/ACK'


### PR DESCRIPTION
This parameter is optional in python 3.8 and 3.9 and has been removed in python 3.10 https://docs.python.org/3.8/library/asyncio-stream.html#asyncio.open_connection https://docs.python.org/3.10/library/asyncio-stream.html#asyncio.open_connection